### PR TITLE
Changed Mie_data.jl: Addition of parallelization process

### DIFF
--- a/99_codes_for_Mie/Mie_data.jl
+++ b/99_codes_for_Mie/Mie_data.jl
@@ -217,15 +217,22 @@ S(r, θ, ϕ) = 1/2 * real(
 
 #=====================================================================#
 # === 散乱強度（S）を評価 ===
+p = Progress(Ny, "Computing in parallel...")
+
 result_arr = zeros(Float64, Ny, Nx)
-@showprogress for j in 1:Ny
+
+Threads.@threads for j in 1:Ny
     for i in 1:Nx
-        r = sqrt(x[i]^2 + y[j]^2 + z^2)       # すでに[m]
-        θ = acos(z / r)                       # z, rともに[m] ⇒ OK
-        ϕ = (x[i] == 0 && y[j] == 0) ? 0.0 : atan(y[j], x[i])                  # atan(y, x) で極座標φ
-        result_arr[j, i] = real(S(r, θ, ϕ))   # S: Eq. 40
+        r = sqrt(x[i]^2 + y[j]^2 + z^2)
+        θ = acos(z / r)
+        ϕ = (x[i] == 0 && y[j] == 0) ? 0.0 : atan(y[j], x[i])
+
+        result_arr[j, i] = real(S(r, θ, ϕ))
     end
+    next!(p)
 end
+
+finish!(p)
 
 # === 出力先の設定 ===
 output_dir = "../data"  # ここで自由にフォルダ名を指定


### PR DESCRIPTION
- Applied `Threads.@threads` to the double-loop process, which takes a long time to compute, and parallelization by multi-threading is performed.

- Changed the `ProgressMeter` to a manual update format.

- To use this parallelization, you need to start Julia in multi-threading mode from the terminal, for example: `>> julia -t auto`